### PR TITLE
Add public home view and campaign model improvements

### DIFF
--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.ui)
     implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.foundation.layout)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/src/app/src/main/java/com/ipca/socialstore/MainActivity.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/MainActivity.kt
@@ -34,6 +34,7 @@ import com.ipca.socialstore.presentation.views.stock.List.ListAllStockViewModel
 import com.ipca.socialstore.presentation.views.stock.List.StockItemDetailView
 import com.ipca.socialstore.presentation.ui.theme.SocialStoreTheme
 import com.ipca.socialstore.presentation.views.authentication.resetPassword.ResetPasswordView
+import com.ipca.socialstore.presentation.views.home.notUserHome.NotUserHomeHomeView
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -52,11 +53,14 @@ class MainActivity : ComponentActivity() {
             val startDestination = if(mainState.isLoggedIn)
                 DefaultRoutes.DefaultHome
             else
-                GeneralRoutes.Login
+                GeneralRoutes.NotUserHome
 
             SocialStoreTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     NavHost(navController = navController, startDestination = startDestination){
+                        composable<GeneralRoutes.NotUserHome>{
+                            NotUserHomeHomeView(modifier = Modifier, navController = navController, userRole = mainState.userRole)
+                        }
                         composable<GeneralRoutes.Login>{
                             LoginView(modifier = Modifier.padding(innerPadding),
                                 navController = navController, userRole = mainState.userRole)
@@ -78,6 +82,7 @@ class MainActivity : ComponentActivity() {
                         composable<DefaultRoutes.DefaultHome>{
                             DefaultHomeView(modifier = Modifier.padding(innerPadding),
                                 navController = navController, userRole = mainState.userRole)
+                            //PublicHomeScreenMockup()
                         }
                         composable<GeneralRoutes.ResetPassword>{
                             ResetPasswordView(modifier = Modifier.padding(innerPadding),

--- a/src/app/src/main/java/com/ipca/socialstore/data/models/CampaignModel.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/data/models/CampaignModel.kt
@@ -11,6 +11,12 @@ data class CampaignModel(
     @SerialName("name")
     val name : String,
 
+    @SerialName("description")
+    val description : String,
+
+    @SerialName("category")
+    val category : String,
+
     @SerialName("date")
     val date : String
 )

--- a/src/app/src/main/java/com/ipca/socialstore/presentation/routes/GeneralRoutes.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/presentation/routes/GeneralRoutes.kt
@@ -10,4 +10,7 @@ sealed class GeneralRoutes {
     object Register : GeneralRoutes()
     @Serializable
     object ResetPassword : GeneralRoutes()
+
+    @Serializable
+    object NotUserHome : GeneralRoutes()
 }

--- a/src/app/src/main/java/com/ipca/socialstore/presentation/views/authentication/login/LoginView.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/presentation/views/authentication/login/LoginView.kt
@@ -93,7 +93,7 @@ fun LoginViewContent(modifier: Modifier,
                 .padding(padding)
                 .padding(24.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically)
         ) {
             Surface(
                 modifier = Modifier.size(80.dp),
@@ -110,8 +110,6 @@ fun LoginViewContent(modifier: Modifier,
                 )
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
-
             Text(
                 text = "Social Store",
                 style = MaterialTheme.typography.headlineMedium,
@@ -125,8 +123,6 @@ fun LoginViewContent(modifier: Modifier,
                 color = Color.Gray
             )
 
-            Spacer(modifier = Modifier.height(48.dp))
-
             TextFieldValueComponent(
                 modifier = Modifier,
                 label = "Email",
@@ -134,8 +130,6 @@ fun LoginViewContent(modifier: Modifier,
                 icon = Icons.Default.Email,
                 onValueUpdate = onEmailUpdate
             )
-
-            Spacer(modifier = Modifier.height(16.dp))
 
             TextFieldPasswordComponent(
                 modifier = Modifier,
@@ -149,8 +143,6 @@ fun LoginViewContent(modifier: Modifier,
                 }
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
-
             Button(
                 onClick = onLogin,
                 modifier = Modifier
@@ -160,8 +152,6 @@ fun LoginViewContent(modifier: Modifier,
             ) {
                 Text("Entrar", fontSize = 16.sp, fontWeight = FontWeight.Bold)
             }
-
-            Spacer(modifier = Modifier.weight(1f))
 
             if (uiState.error != null) {
                 ErrorTextComponent(message = uiState.error!!.asString())

--- a/src/app/src/main/java/com/ipca/socialstore/presentation/views/authentication/register/RegisterView.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/presentation/views/authentication/register/RegisterView.kt
@@ -146,7 +146,7 @@ fun RegisterViewContent(
                 .padding(24.dp)
                 .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically)
         ) {
             Icon(
                 imageVector = Icons.Default.Add,
@@ -154,8 +154,6 @@ fun RegisterViewContent(
                 modifier = Modifier.size(64.dp),
                 tint = MaterialTheme.colorScheme.primary
             )
-
-            Spacer(modifier = Modifier.height(24.dp))
 
             Text(
                 text = "Criar Conta",
@@ -169,8 +167,6 @@ fun RegisterViewContent(
                 color = Color.Gray
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
-
             TextFieldValueComponent(
                 modifier = Modifier,
                 label = "Nome Completo",
@@ -178,8 +174,6 @@ fun RegisterViewContent(
                 icon = Icons.Default.Star,
                 onValueUpdate = onNameUpdate
             )
-
-            Spacer(modifier = Modifier.height(16.dp))
 
             TextFieldDateComponent(
                 modifier = Modifier,
@@ -189,8 +183,6 @@ fun RegisterViewContent(
                 onDatePickerUpdate = {showDatePicker = true}
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
-
             TextFieldValueComponent(
                 modifier = Modifier,
                 label = "Email",
@@ -199,15 +191,11 @@ fun RegisterViewContent(
                 onValueUpdate = onEmailUpdate
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
-
             TextFieldPasswordComponent(
                 modifier = Modifier,
                 password = uiState.password,
                 onPasswordUpdate = onPasswordUpdate
             )
-
-            Spacer(modifier = Modifier.height(32.dp))
 
             Button(
                 onClick = onRegister,
@@ -218,8 +206,6 @@ fun RegisterViewContent(
             ) {
                 Text("Registar", fontSize = 16.sp, fontWeight = FontWeight.Bold)
             }
-
-            Spacer(modifier = Modifier.height(24.dp))
 
             if (uiState.error != null) {
                 ErrorTextComponent(message = uiState.error!!.asString())

--- a/src/app/src/main/java/com/ipca/socialstore/presentation/views/authentication/resetPassword/ResetPasswordView.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/presentation/views/authentication/resetPassword/ResetPasswordView.kt
@@ -109,7 +109,7 @@ fun ResetPasswordViewContent(
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically)
         ) {
             Icon(
                 imageVector = if (uiState.requestedReset) Icons.Default.Email else Icons.Default.Close,
@@ -123,13 +123,15 @@ fun ResetPasswordViewContent(
                 enter = fadeIn() + slideInVertically(),
                 exit = fadeOut()
             ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically)
+                ) {
                     Text(
                         "Esqueceu a palavra-passe?",
                         style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.Bold
                     )
-                    Spacer(Modifier.height(8.dp))
 
                     Text(
                         "Insira o seu email para receber o código de recuperação.",
@@ -145,8 +147,6 @@ fun ResetPasswordViewContent(
                         icon = Icons.Default.Star,
                         onValueUpdate = onEmailUpdate
                     )
-
-                    Spacer(Modifier.height(24.dp))
 
                     Button(
                         onClick = {
@@ -165,7 +165,8 @@ fun ResetPasswordViewContent(
                 enter = fadeIn() + slideInVertically(),
                 exit = fadeOut()
             ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
                         "Definir Nova Palavra-passe",
                         style = MaterialTheme.typography.headlineSmall,
@@ -232,7 +233,7 @@ fun ResetPasswordViewContent(
 @Composable
 fun ResetPasswordPreview(){
     SocialStoreTheme() {
-        val uiState = ResetState(email = "", error = null, isLoading = false)
+        val uiState = ResetState(email = "", error = null, isLoading = false, requestedReset = true)
 
         ResetPasswordViewContent(modifier = Modifier,
             onClickSendEmail = { Unit},

--- a/src/app/src/main/java/com/ipca/socialstore/presentation/views/campaign/create/CreateCampaignView.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/presentation/views/campaign/create/CreateCampaignView.kt
@@ -66,7 +66,7 @@ fun CreateCampaignViewContent(
 @Composable
 fun PreviewCreateCampaignViewContent(){
     SocialStoreTheme() {
-        val campaign = CampaignModel(name = "", date = "")
+        val campaign = CampaignModel(name = "", date = "", description = "", category = "")
         val uiState = CampaignState(campaign,false,null,false)
         CreateCampaignViewContent(
             modifier = Modifier,

--- a/src/app/src/main/java/com/ipca/socialstore/presentation/views/campaign/create/CreateCampaignViewModel.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/presentation/views/campaign/create/CreateCampaignViewModel.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 
 
 data class CampaignState(
-    val campaign : CampaignModel = CampaignModel(name = "", date = ""),
+    val campaign : CampaignModel = CampaignModel(name = "", date = "", description = "", category = ""),
     val isLoading : Boolean = false,
     val error: ErrorText? = null,
     val isCreated : Boolean  = false

--- a/src/app/src/main/java/com/ipca/socialstore/presentation/views/home/notUserHome/NotUserHomeView.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/presentation/views/home/notUserHome/NotUserHomeView.kt
@@ -1,0 +1,394 @@
+package com.ipca.socialstore.presentation.views.home.notUserHome
+
+import androidx.compose.runtime.getValue
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.ipca.socialstore.data.enums.UserRole
+import com.ipca.socialstore.data.models.CampaignModel
+import com.ipca.socialstore.presentation.objects.NavigationLogic
+import com.ipca.socialstore.presentation.routes.GeneralRoutes
+import com.ipca.socialstore.presentation.ui.theme.SocialStoreTheme
+import kotlin.text.uppercase
+
+@Composable
+fun NotUserHomeHomeView(modifier: Modifier, navController: NavController, userRole: UserRole) {
+    val homeViewModel: NotUserHomeViewModel = viewModel()
+    val uiState by homeViewModel.uiState
+
+    NotUserHomeViewContent(
+        modifier = modifier,
+        uiState = uiState,
+        onClickLogin = {
+            NavigationLogic.navigateTo(
+                navController = navController, userRole = userRole, route = GeneralRoutes.Login
+            )
+        },
+        onCampaignClick = {}
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotUserHomeViewContent(
+    modifier: Modifier,
+    uiState: NotUserHomeState,
+    onClickLogin: () -> Unit,
+    onCampaignClick: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Icon(Icons.Default.Star, null, tint = MaterialTheme.colorScheme.primary)
+                        Text("Social Store", fontWeight = FontWeight.Bold)
+                    }
+                },
+                actions = {
+                    TextButton(onClick = onClickLogin) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                            Icon(Icons.Default.Star, null, modifier = Modifier.size(18.dp))
+                            Text("Entrar")
+                        }
+                    }
+                }
+            )
+        }
+    ) { padding ->
+
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+
+            Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)) {
+                Text(
+                    "Ajudar nunca foi tão fácil.",
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = Color(0xFF1A1A1A)
+                )
+                Text(
+                    "Descubra as campanhas a decorrer no IPCA e faça a diferença hoje.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = Color.Gray,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+
+            if (uiState.campaignList.isNotEmpty()) {
+                LazyRow(
+                    contentPadding = PaddingValues(horizontal = 20.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(uiState.campaignList) { campaign ->
+                        PublicCampaignCard(campaign, onClick = onCampaignClick)
+                    }
+                }
+            } else {
+                Box(modifier = Modifier.padding(horizontal = 20.dp)) {
+                    EmptyCampaignsCard(onClick = {})
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                StatItem("500+", "Pessoas Apoiadas")
+                StatItem("12", "Bens Recolhidos")
+            }
+
+            Box(modifier = Modifier.padding(horizontal = 20.dp)) {
+                NeedHelpBanner(onClick = onClickLogin)
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color(0xFFF5F5F5))
+                    .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("Junte-se à causa", fontWeight = FontWeight.Bold)
+                Text("SAS IPCA - Serviços de Ação Social", style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+            }
+        }
+    }
+}
+
+@Composable
+fun EmptyCampaignsCard(onClick: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF3E0))
+    ) {
+        Row(
+            modifier = Modifier.padding(20.dp),
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Surface(
+                shape = RoundedCornerShape(12.dp),
+                color = Color(0xFFFFB74D),
+                modifier = Modifier.size(48.dp)
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(Icons.Default.Star, null, tint = Color.White)
+                }
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Column {
+                    Text(
+                        "Sem campanhas ativas",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFFE65100)
+                    )
+                    Text(
+                        "Mas a Loja Social precisa sempre de si. Saiba como fazer um donativo espontâneo.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color(0xFFE65100).copy(alpha = 0.8f)
+                    )
+                }
+
+                Button(
+                    onClick = onClick,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFFE65100),
+                        contentColor = Color.White
+                    ),
+                    contentPadding = PaddingValues(horizontal = 24.dp, vertical = 8.dp),
+                    modifier = Modifier.height(40.dp).width(200.dp)
+                ) {
+                    Text(
+                        "Ver Mais",
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PublicCampaignCard(campaign: CampaignModel, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .width(280.dp)
+            .height(300.dp)
+            .clickable { onClick() },
+        shape = RoundedCornerShape(20.dp),
+        elevation = CardDefaults.cardElevation(6.dp)
+    ) {
+        Column {
+            Box(
+                modifier = Modifier
+                    .weight(0.55f)
+                    .fillMaxWidth()
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Brush.verticalGradient(listOf(Color.Transparent, Color.Black.copy(0.6f))))
+                )
+
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(16.dp)
+                ) {
+                    Surface(
+                        color = Color.White,
+                        shape = RoundedCornerShape(6.dp),
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    ) {
+                        Text(
+                            text = campaign.category.uppercase(),
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.Black
+                        )
+                    }
+                    Text(
+                        text = campaign.name,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier
+                    .weight(0.45f)
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    campaign.description,
+                    maxLines = 2,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.Gray
+                )
+
+                Button(
+                    onClick = onClick,
+                    modifier = Modifier.fillMaxWidth().height(40.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = Color.Black)
+                ) {
+                    Text("Ver")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun NeedHelpBanner(onClick: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFE3F2FD)) // Azul suave
+    ) {
+        Row(
+            modifier = Modifier.padding(20.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    "Precisa de apoio social?",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF1565C0)
+                )
+
+                Text(
+                    "Se faz parte do IPCA e encontra-se com dificuldades, submeta a sua candidatura.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color(0xFF1565C0).copy(0.8f)
+                )
+
+                Button(
+                    onClick = onClick,
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF1565C0)),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    modifier = Modifier.height(36.dp)
+                ) {
+                    Text("Pedir Apoio", fontSize = 12.sp)
+                }
+            }
+            Icon(
+                imageVector = Icons.Default.Favorite,
+                contentDescription = null,
+                modifier = Modifier.size(60.dp),
+                tint = Color(0xFF1565C0).copy(alpha = 0.4f)
+            )
+        }
+    }
+}
+
+@Composable
+fun StatItem(value: String, label: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(value, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+        Text(label, style = MaterialTheme.typography.labelSmall, color = Color.Gray)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NotUserHomePreview(){
+    SocialStoreTheme {
+        val mockCampaigns = listOf(
+            CampaignModel(
+                id = 1,
+                name = "Natal Solidário",
+                description = "Ajude-nos a compor 500 cabazes para as famílias mais carenciadas da comunidade académica.",
+                category = "Alimentar",
+                date = "2025-12-25"
+            ),
+            CampaignModel(
+                id = 2,
+                name = "Kit Escolar 2026",
+                description = "Recolha de cadernos, canetas e calculadoras para o segundo semestre.",
+                category = "Educação",
+                date = "2026-02-10"
+            ),
+            CampaignModel(
+                id = 3,
+                name = "Inverno Quente",
+                description = "Estamos a recolher casacos e mantas em bom estado.",
+                category = "Vestuário",
+                date = "2025-11-30"
+            )
+        )
+
+        val uiState = NotUserHomeState(
+            error = null,
+            campaignList = emptyList(),
+            isLoading = false
+        )
+
+        NotUserHomeViewContent(
+            modifier = Modifier,
+            uiState = uiState,
+            onCampaignClick = {},
+            onClickLogin = {}
+        )
+    }
+}

--- a/src/app/src/main/java/com/ipca/socialstore/presentation/views/home/notUserHome/NotUserHomeViewModel.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/presentation/views/home/notUserHome/NotUserHomeViewModel.kt
@@ -1,0 +1,40 @@
+package com.ipca.socialstore.presentation.views.home.notUserHome
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import com.ipca.socialstore.data.models.CampaignModel
+import com.ipca.socialstore.presentation.utils.ErrorText
+import com.ipca.socialstore.presentation.views.home.defaultHome.DefaultHomeState
+import dagger.hilt.android.lifecycle.HiltViewModel
+
+data class NotUserHomeState (
+    var error : ErrorText? = null,
+    var campaignList: List<CampaignModel> = listOf(
+        CampaignModel(
+            id = 1,
+            name = "Natal Solidário",
+            description = "Ajude-nos a compor 500 cabazes para as famílias mais carenciadas da comunidade académica.",
+            category = "Alimentar",
+            date = "2025-12-25"
+        ),
+        CampaignModel(
+            id = 2,
+            name = "Kit Escolar 2026",
+            description = "Recolha de cadernos, canetas e calculadoras para o segundo semestre.",
+            category = "Educação",
+            date = "2026-02-10"
+        ),
+        CampaignModel(
+            id = 3,
+            name = "Inverno Quente",
+            description = "Estamos a recolher casacos e mantas em bom estado.",
+            category = "Vestuário",
+            date = "2025-11-30"
+        )
+    ),
+    var isLoading : Boolean = false,
+)
+
+class NotUserHomeViewModel : ViewModel() {
+    var uiState = mutableStateOf(NotUserHomeState())
+}

--- a/src/app/src/main/java/com/ipca/socialstore/presentation/views/mockups/CampanhasMockup.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/presentation/views/mockups/CampanhasMockup.kt
@@ -1,0 +1,259 @@
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+// --- MODELO DE DADOS RENOMEADO ---
+data class CampaignTest(
+    val id: String,
+    val title: String,
+    val description: String,
+    val category: String, // Alimentar, Escolar, Roupa
+    val currentAmount: Int,
+    val targetAmount: Int,
+    val daysLeft: Int,
+    val color: Color
+)
+
+// --- ECRÃ DE CAMPANHAS ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CampaignsScreenMockup(
+    onCampaignClick: (String) -> Unit = {}
+) {
+    // Categorias para filtro
+    val categories = listOf("Todas", "Alimentar", "Material Escolar", "Roupa", "Dinheiro")
+    var selectedCategory by remember { mutableStateOf("Todas") }
+
+    // Dados Fictícios usando CampaignTest
+    val campaigns = listOf(
+        CampaignTest("1", "Recolha de Natal 2025", "Ajude-nos a compor 500 cabazes para as famílias mais carenciadas da comunidade académica.", "Alimentar", 350, 500, 12, Color(0xFFC62828)),
+        CampaignTest("2", "Kit Escolar Solidário", "Recolha de cadernos, canetas e calculadoras para o segundo semestre.", "Material Escolar", 120, 200, 45, Color(0xFF1976D2)),
+        CampaignTest("3", "Roupa Quente", "Recolha de casacos e mantas para o Inverno.", "Roupa", 45, 100, 5, Color(0xFFF57C00))
+    )
+
+    // Filtragem
+    val filteredCampaigns = if (selectedCategory == "Todas") {
+        campaigns
+    } else {
+        campaigns.filter { it.category == selectedCategory }
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Campanhas Ativas", fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    IconButton(onClick = {}) { Icon(Icons.Default.ArrowBack, null) }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+        ) {
+
+            // 1. FILTROS (Chips Horizontais)
+            LazyRow(
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(categories) { category ->
+                    FilterChip(
+                        selected = selectedCategory == category,
+                        onClick = { selectedCategory = category },
+                        label = { Text(category) },
+                        leadingIcon = if (selectedCategory == category) {
+                            { Icon(Icons.Default.Check, null, modifier = Modifier.size(16.dp)) }
+                        } else null
+                    )
+                }
+            }
+
+            // 2. LISTA DE CAMPANHAS
+            LazyColumn(
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                // Header motivacional
+                item {
+                    Text(
+                        "Juntos fazemos a diferença.",
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+                }
+
+                items(filteredCampaigns) { campaign ->
+                    CampaignCard(campaign, onClick = { onCampaignClick(campaign.id) })
+                }
+            }
+        }
+    }
+}
+
+// --- COMPONENTE DO CARTÃO DE CAMPANHA ---
+@Composable
+fun CampaignCard(campaign: CampaignTest, onClick: () -> Unit) {
+    val progress = campaign.currentAmount.toFloat() / campaign.targetAmount.toFloat()
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(4.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White)
+    ) {
+        Column {
+            // 1. IMAGEM DE CAPA (Simulada com Box)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(140.dp)
+                    .background(
+                        Brush.linearGradient(
+                            colors = listOf(campaign.color, campaign.color.copy(alpha = 0.6f))
+                        )
+                    )
+            ) {
+                // Badge de Categoria
+                Surface(
+                    color = Color.White.copy(alpha = 0.9f),
+                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier.padding(12.dp).align(Alignment.TopStart)
+                ) {
+                    Text(
+                        text = campaign.category.uppercase(),
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = campaign.color
+                    )
+                }
+
+                // Ícone decorativo
+                Icon(
+                    imageVector = Icons.Default.Star,
+                    contentDescription = null,
+                    tint = Color.White.copy(alpha = 0.3f),
+                    modifier = Modifier.size(100.dp).align(Alignment.BottomEnd).offset(x = 20.dp, y = 20.dp)
+                )
+            }
+
+            // 2. CONTEÚDO
+            Column(modifier = Modifier.padding(16.dp)) {
+
+                // Título e Dias Restantes
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top
+                ) {
+                    Text(
+                        text = campaign.title,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    // Chip de Tempo
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.Outlined.Star, null, modifier = Modifier.size(16.dp), tint = Color.Gray)
+                        Spacer(Modifier.width(4.dp))
+                        Text(
+                            "${campaign.daysLeft} dias",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if(campaign.daysLeft < 7) Color.Red else Color.Gray,
+                            fontWeight = if(campaign.daysLeft < 7) FontWeight.Bold else FontWeight.Normal
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(8.dp))
+
+                Text(
+                    text = campaign.description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.Gray,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Spacer(Modifier.height(20.dp))
+
+                // 3. BARRA DE PROGRESSO
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "${(progress * 100).toInt()}% angariado",
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = campaign.color
+                    )
+                    Text(
+                        text = "${campaign.currentAmount} / ${campaign.targetAmount}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = Color.Gray
+                    )
+                }
+
+                Spacer(Modifier.height(6.dp))
+
+                LinearProgressIndicator(
+                    progress = { progress },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(8.dp)
+                        .clip(RoundedCornerShape(4.dp)),
+                    color = campaign.color,
+                    trackColor = campaign.color.copy(alpha = 0.1f),
+                )
+
+                Spacer(Modifier.height(16.dp))
+
+                // Botão de Ação
+                Button(
+                    onClick = onClick,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFF5F5F5), contentColor = Color.Black),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text("Contribuir Agora")
+                    Spacer(Modifier.width(8.dp))
+                    Icon(Icons.Default.ArrowForward, null, modifier = Modifier.size(16.dp))
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun CampaignsPreview() {
+    MaterialTheme {
+        CampaignsScreenMockup()
+    }
+}

--- a/src/app/src/main/java/com/ipca/socialstore/presentation/views/mockups/HomeMockup.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/presentation/views/mockups/HomeMockup.kt
@@ -1,0 +1,249 @@
+package com.ipca.socialstore.presentation.views.mockups
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+// --- ECRÃ HOME (NÃO BENEFICIÁRIO) ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NonBeneficiaryHomeScreenMockup(
+    onStartApplicationClick: () -> Unit = {},
+    onSeeMoreClick: () -> Unit = {}
+) {
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Social Store", fontWeight = FontWeight.Bold) },
+                actions = {
+                    IconButton(onClick = { /* Menu Perfil */ }) {
+                        Icon(Icons.Default.Person, null)
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+
+            // 1. HERO SECTION (Chamada para Ação Principal)
+            HeroApplicationBanner(onClick = onStartApplicationClick)
+
+            // 2. COMO FUNCIONA (Passos)
+            Text("Como funciona?", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+            HowItWorksSection()
+
+            // 3. SERVIÇOS DISPONÍVEIS (O que podem ganhar)
+            Text("Apoios Disponíveis", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+            AvailableServicesRow()
+
+            // 4. CRITÉRIOS / DÚVIDAS
+            InfoCard()
+
+            // Espaço fundo
+            Spacer(Modifier.height(32.dp))
+        }
+    }
+}
+
+// --- COMPONENTES ---
+
+@Composable
+fun HeroApplicationBanner(onClick: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        elevation = CardDefaults.cardElevation(8.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(Color(0xFF1976D2), Color(0xFF1565C0))
+                    )
+                )
+                .padding(24.dp)
+        ) {
+            Column(
+                horizontalAlignment = Alignment.Start
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Star, null, tint = Color.White, modifier = Modifier.size(32.dp))
+                    Spacer(Modifier.width(12.dp))
+                    Text(
+                        "Precisa de Apoio?",
+                        color = Color.White,
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+
+                Spacer(Modifier.height(12.dp))
+
+                Text(
+                    "A Loja Social está aqui para ajudar a comunidade académica. Submeta a sua candidatura para aceder a bens alimentares, material escolar e mais.",
+                    color = Color.White.copy(alpha = 0.9f),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+
+                Spacer(Modifier.height(24.dp))
+
+                Button(
+                    onClick = onClick,
+                    modifier = Modifier.fillMaxWidth().height(50.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = Color.White, contentColor = Color(0xFF1565C0)),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Text("Candidatar-me Agora", fontWeight = FontWeight.Bold, fontSize = 16.sp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun HowItWorksSection() {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        StepItem("1", "Preencher\nDados", Icons.Default.Star)
+        StepDivider()
+        StepItem("2", "Análise\nTécnica", Icons.Default.Star)
+        StepDivider()
+        StepItem("3", "Receber\nApoio", Icons.Default.Star)
+    }
+}
+
+@Composable
+fun RowScope.StepDivider() {
+    Box(
+        modifier = Modifier
+            .weight(1f)
+            .height(2.dp)
+            .align(Alignment.CenterVertically)
+            .background(Color.LightGray)
+    )
+}
+
+@Composable
+fun StepItem(number: String, text: String, icon: ImageVector) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primaryContainer,
+            modifier = Modifier.size(50.dp)
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(icon, null, tint = MaterialTheme.colorScheme.primary)
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.width(70.dp),
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+            lineHeight = 14.sp
+        )
+    }
+}
+
+@Composable
+fun AvailableServicesRow() {
+    val services = listOf(
+        "Alimentação" to Icons.Default.Star,
+        "Vestuário" to Icons.Default.Star,
+        "Escolar" to Icons.Default.Star,
+        "Higiene" to Icons.Default.Star,
+        "Mobiliário" to Icons.Default.Star
+    )
+
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(horizontal = 4.dp)
+    ) {
+        items(services) { (name, icon) ->
+            ServiceCard(name, icon)
+        }
+    }
+}
+
+@Composable
+fun ServiceCard(name: String, icon: ImageVector) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFF5F5F5)),
+        modifier = Modifier.size(100.dp)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(icon, null, tint = Color.Gray, modifier = Modifier.size(32.dp))
+            Spacer(Modifier.height(8.dp))
+            Text(name, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+fun InfoCard() {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFE3F2FD)),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(Icons.Outlined.Info, null, tint = MaterialTheme.colorScheme.primary)
+            Spacer(Modifier.width(16.dp))
+            Column {
+                Text("Quem pode candidatar-se?", fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary)
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Estudantes, docentes e funcionários do IPCA que se encontrem em situação de vulnerabilidade económica comprovada.",
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        }
+    }
+}
+
+// --- PREVIEW ---
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun NonBeneficiaryHomePreview() {
+    MaterialTheme {
+        NonBeneficiaryHomeScreenMockup()
+    }
+}

--- a/src/app/src/main/java/com/ipca/socialstore/presentation/views/mockups/UserHomeMockup.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/presentation/views/mockups/UserHomeMockup.kt
@@ -1,0 +1,345 @@
+package com.ipca.socialstore.presentation.views.mockups
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+// --- ENUM DE ESTADOS ATUALIZADO ---
+enum class UserStatus {
+    PENDING,            // Em análise (Tracker + FAQs)
+    NEEDS_CORRECTION,   // Ação necessária (Aviso Amarelo/Laranja)
+    REJECTED,           // Recusado (Explicação + Agendar Reunião)
+    ACTIVE              // Aceite (Cartão Digital)
+}
+
+// --- ECRÃ PRINCIPAL ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UserHomeScreenMockup() {
+
+    // TROCA AQUI O ESTADO PARA TESTARES OS VISUAIS:
+    // UserStatus.PENDING, UserStatus.NEEDS_CORRECTION, UserStatus.REJECTED, UserStatus.ACTIVE
+    val userStatus by remember { mutableStateOf(UserStatus.ACTIVE)}
+    val userName = "Maria Silva"
+
+    Scaffold(
+        topBar = {
+            // TopBar mais limpa
+            CenterAlignedTopAppBar(
+                title = {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text("Social Store", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                        Text(
+                            text = when(userStatus) {
+                                UserStatus.ACTIVE -> "Bem-vindo(a)"
+                                UserStatus.PENDING -> "Processo a decorrer"
+                                UserStatus.NEEDS_CORRECTION -> "Ação Necessária"
+                                UserStatus.REJECTED -> "Estado do Pedido"
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.Gray
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = {}) {
+                        BadgedBox(badge = { Badge { Text("1") } }) {
+                            Icon(Icons.Outlined.Notifications, null)
+                        }
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(padding)
+                .padding(horizontal = 20.dp)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+
+            // 1. ÁREA HERO (O Cartão Principal)
+            item {
+                Spacer(Modifier.height(8.dp))
+                when (userStatus) {
+                    UserStatus.ACTIVE -> ActiveCard(userName)
+                    UserStatus.PENDING -> PendingTrackerCard()
+                    UserStatus.NEEDS_CORRECTION -> CorrectionCard()
+                    UserStatus.REJECTED -> RejectedCard()
+                }
+            }
+
+            // 2. CONTEÚDO DE APOIO (Para não ficar vazio)
+            item {
+                when (userStatus) {
+                    // Se estiver PENDENTE: Mostra FAQs para acalmar ansiedade
+                    UserStatus.PENDING -> PendingContentSection()
+
+                    // Se precisar CORREÇÃO: Mostra botão grande e instruções
+                    UserStatus.NEEDS_CORRECTION -> CorrectionContentSection()
+
+                    // Se estiver REJEITADO: Mostra opções de recurso/apoio
+                    UserStatus.REJECTED -> RejectedContentSection()
+
+                    // Se estiver ATIVO: Menu normal
+                    UserStatus.ACTIVE -> ActiveMenuSection()
+                }
+            }
+
+            // Espaço final
+            item { Spacer(Modifier.height(32.dp)) }
+        }
+    }
+}
+
+// ==========================================
+// SECÇÕES DE CONTEÚDO (O QUE VAI POR BAIXO)
+// ==========================================
+
+@Composable
+fun PendingContentSection() {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text("Perguntas Frequentes", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+
+        InfoCard(
+            icon = Icons.Outlined.Star,
+            title = "Quanto tempo demora?",
+            desc = "A análise demora, em média, 3 a 5 dias úteis. Receberá uma notificação assim que terminarmos."
+        )
+        InfoCard(
+            icon = Icons.Outlined.Phone,
+            title = "Precisa de urgência?",
+            desc = "Se a sua situação é crítica, contacte a linha de apoio social: 253 000 000."
+        )
+
+        Button(
+            onClick = {},
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFEEEEEE), contentColor = Color.Black)
+        ) {
+            Icon(Icons.Default.Star, null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text("Ver a minha candidatura submetida")
+        }
+    }
+}
+
+@Composable
+fun CorrectionContentSection() {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text("O que precisa de fazer:", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+
+        // Item específico do erro (Simulado)
+        Card(
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            elevation = CardDefaults.cardElevation(2.dp),
+            border = BorderStroke(1.dp, Color(0xFFFFB74D))
+        ) {
+            Row(modifier = Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Star, null, tint = Color(0xFFF57C00))
+                Spacer(Modifier.width(16.dp))
+                Column {
+                    Text("IRS Incompleto", fontWeight = FontWeight.Bold)
+                    Text("O documento enviado não está legível. Por favor digitalize novamente.", style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+                }
+            }
+        }
+
+        Button(
+            onClick = { /* Navegar para editar */ },
+            modifier = Modifier.fillMaxWidth().height(50.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFF57C00)) // Laranja
+        ) {
+            Text("Resolver Problema Agora")
+        }
+    }
+}
+
+@Composable
+fun RejectedContentSection() {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text("Outras Opções", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+
+        InfoCard(
+            icon = Icons.Default.Star,
+            title = "Agendar Reunião",
+            desc = "Gostaria de rever o seu processo com um assistente social? Marque um atendimento presencial."
+        )
+
+        OutlinedButton(
+            onClick = {},
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Ver Detalhes da Decisão")
+        }
+    }
+}
+
+@Composable
+fun ActiveMenuSection() {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text("Acesso Rápido", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            MenuButton("Novo Pedido", Icons.Default.Star, Color(0xFFE3F2FD), Modifier.weight(1f))
+            MenuButton("Histórico", Icons.Default.Star, Color(0xFFF3E5F5), Modifier.weight(1f))
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            MenuButton("Agenda", Icons.Default.Star, Color(0xFFE8F5E9), Modifier.weight(1f))
+            MenuButton("Perfil", Icons.Default.Person, Color(0xFFFFF3E0), Modifier.weight(1f))
+        }
+    }
+}
+
+// ==========================================
+// CARDS DE TOPO (HERO)
+// ==========================================
+
+@Composable
+fun CorrectionCard() {
+    Card(
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF3E0)), // Laranja claro
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(24.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Warning, null, tint = Color(0xFFE65100), modifier = Modifier.size(32.dp))
+                Spacer(Modifier.width(12.dp))
+                Text("Atenção Necessária", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold, color = Color(0xFFE65100))
+            }
+            Spacer(Modifier.height(12.dp))
+            Text("Detetámos um problema com a sua candidatura que impede a aprovação. Por favor, verifique os detalhes abaixo.",
+                style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+fun RejectedCard() {
+    Card(
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFFFEBEE)), // Vermelho claro
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(24.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Star, null, tint = Color(0xFFC62828), modifier = Modifier.size(32.dp))
+                Spacer(Modifier.width(12.dp))
+                Text("Não Aceite", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold, color = Color(0xFFC62828))
+            }
+            Spacer(Modifier.height(12.dp))
+            Text("Lamentamos, mas a sua candidatura não cumpre os requisitos atuais para apoio. Pode consultar os motivos detalhados ou agendar um esclarecimento.",
+                style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+fun PendingTrackerCard() {
+    // Igual ao anterior mas mais compacto se quiseres
+    Card(colors = CardDefaults.cardColors(containerColor = Color(0xFFF5F5F5)), shape = RoundedCornerShape(24.dp)) {
+        Column(modifier = Modifier.padding(24.dp)) {
+            Text("Estado da Candidatura", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(16.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                CircularProgressIndicator(progress = { 0.5f }, modifier = Modifier.size(48.dp))
+                Spacer(Modifier.width(16.dp))
+                Column {
+                    Text("Em Análise Técnica", fontWeight = FontWeight.Bold)
+                    Text("Atualizado há 2 dias", style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ActiveCard(name: String) {
+    // O teu cartão bonito
+    Card(
+        shape = RoundedCornerShape(24.dp),
+        elevation = CardDefaults.cardElevation(8.dp),
+        modifier = Modifier.fillMaxWidth().height(180.dp)
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize().background(
+                Brush.horizontalGradient(listOf(Color(0xFF1976D2), Color(0xFF42A5F5)))
+            )
+        ) {
+            Column(modifier = Modifier.padding(24.dp).fillMaxSize(), verticalArrangement = Arrangement.SpaceBetween) {
+                Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+                    Text("Cartão Digital", color = Color.White.copy(0.8f))
+                    Icon(Icons.Default.Star, null, tint = Color.White)
+                }
+                Text(name, style = MaterialTheme.typography.headlineSmall, color = Color.White, fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}
+
+// ==========================================
+// COMPONENTES GENÉRICOS
+// ==========================================
+
+@Composable
+fun InfoCard(icon: ImageVector, title: String, desc: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.White)
+            .padding(16.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        Icon(icon, null, tint = MaterialTheme.colorScheme.primary)
+        Spacer(Modifier.width(16.dp))
+        Column {
+            Text(title, fontWeight = FontWeight.SemiBold)
+            Text(desc, style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+        }
+    }
+}
+
+@Composable
+fun MenuButton(title: String, icon: ImageVector, color: Color, modifier: Modifier) {
+    Card(
+        modifier = modifier.height(100.dp).clickable { },
+        colors = CardDefaults.cardColors(containerColor = color),
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp).fillMaxSize(),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Icon(icon, null, tint = Color.Black.copy(0.6f))
+            Text(title, fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewHome() {
+    UserHomeScreenMockup()
+}

--- a/src/gradle/libs.versions.toml
+++ b/src/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ foundationLayout = "1.9.5"
 material3 = "1.4.0"
 ui = "1.10.0"
 foundation = "1.10.0"
+foundationLayoutVersion = "1.10.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -32,6 +33,7 @@ androidx-compose-foundation-layout = { group = "androidx.compose.foundation", na
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "ui" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
+androidx-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout", version.ref = "foundationLayoutVersion" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Introduces NotUserHomeView and NotUserHomeViewModel for unauthenticated users, updates navigation to support a public home screen, and adds mockup views for campaigns and home screens. CampaignModel is extended with description and category fields, and related view models and previews are updated accordingly. Layout improvements are made to authentication views for better spacing.