### PR TITLE
Change expiration date worker interval to 24 hours

### DIFF
--- a/src/app/src/main/java/com/ipca/socialstore/Work/StockWorkManager.kt
+++ b/src/app/src/main/java/com/ipca/socialstore/Work/StockWorkManager.kt
@@ -25,7 +25,7 @@ class StockWorkManager(private val context: Context) {
 
     fun notificationExpirationDate() {
 
-        val syncRequest = PeriodicWorkRequestBuilder<ExpirationDateWorker>(15, TimeUnit.MINUTES)
+        val syncRequest = PeriodicWorkRequestBuilder<ExpirationDateWorker>(24, TimeUnit.HOURS)
             .addTag(TAG_SYNC)
             .build()
 


### PR DESCRIPTION
Updated the PeriodicWorkRequestBuilder in StockWorkManager to schedule ExpirationDateWorker every 24 hours instead of every 15 minutes, reducing the frequency of background work.